### PR TITLE
Add backend package init and adjust imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 +2025-06-23: improve parsing and mapping functions
 +2025-06-23: add requirements file with backend packages
 +2025-06-22: add shortcut panel and setup script
++2025-06-27: make backend a package for relative imports

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Dynamic Data Weaver
+
+This project bootstraps a tiny FastAPI backend and a static frontend. The backend folder is set up as a proper Python package so that modules can be imported with package-relative paths.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,19 +1,19 @@
- from fastapi import FastAPI
- from pydantic import BaseModel
- import logic_engine.interpreter as interp
- 
- app = FastAPI(title="DDW Anti-Normalization API")
- 
+from fastapi import FastAPI
+from pydantic import BaseModel
+from .logic_engine import interpreter as interp
 
- @app.get("/")
- def read_root():
-     return {"msg": "DDW Anti-Normalization API"}
- 
+app = FastAPI(title="DDW Anti-Normalization API")
 
- class Logic(BaseModel):
-     record: str
- 
 
- @app.post("/interpret")
- def interpret(item: Logic):
-     return interp.interpret(item.record)
+@app.get("/")
+def read_root():
+    return {"msg": "DDW Anti-Normalization API"}
+
+
+class Logic(BaseModel):
+    record: str
+
+
+@app.post("/interpret")
+def interpret(item: Logic):
+    return interp.interpret(item.record)

--- a/scripts/bootstrap_anti_norm.py
+++ b/scripts/bootstrap_anti_norm.py
@@ -53,6 +53,7 @@ if not app_py.exists():
     """).strip()+"\n")
 
 # ── logic_engine stubs ────────────────────────────────────
+(root / "backend/__init__.py").touch()
 (root / "backend/logic_engine/__init__.py").touch()
 
 (root / "backend/logic_engine/parser.py").write_text(


### PR DESCRIPTION
## Summary
- make `backend` a package and fix import
- update bootstrap script to create package `__init__`
- document backend package setup
- log change in `CHANGELOG`

## Testing
- `black --check backend/app.py scripts/bootstrap_anti_norm.py`
- `flake8 backend/app.py scripts/bootstrap_anti_norm.py`
- `pyright backend/app.py scripts/bootstrap_anti_norm.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685e4801ddbc832c9b22a54b23a8e27c