### PR TITLE
Add recursive-loop-suppression skill and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 2026-03-13: restore straightforward drag/resize handlers for dashboard cards to preserve prior behavior
 2026-03-13: unify dashboard card move/resize into a global signal-driven interaction core
 2026-03-13: configure flake8 exclusions to avoid virtualenv scan timeouts
+2026-03-20: add recursive-loop-suppression skill for behavior-critique handling

--- a/DSL.md
+++ b/DSL.md
@@ -74,4 +74,3 @@ DaTiX, id1, id2, {StatN, StatC}, {Slot1:1, ..., SlotN:N}
 Ensure:
 - No duplicate keys
 - Column order is significant → rely on **Python dict insertion order** (3.7+) or use OrderedDict to enforce explicit ordering
-

--- a/skills/recursive-loop-suppression/SKILL.md
+++ b/skills/recursive-loop-suppression/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: recursive-loop-suppression
+description: Prevents AI from entering a "Reframe, Repackage, Replay" failure cycle by enforcing structural silence, removing meta-language, and converting feedback directly into behavioral constraints without explanatory overhead. Trigger this skill whenever a user critiques AI behavior, reports a failure, or requests a change in communication style.
+---
+
+## Instructions
+
+### 1. Execute Structural Silence
+
+Upon receiving a failure report, critique, or correction:
+
+- Immediately terminate the current descriptive or explanatory thread.
+- Do not rephrase the user's critique or explain the internal understanding of the error.
+- If no substantive task follows the critique, provide only a brief confirmation (e.g., "Acknowledged" or "Fixed").
+- Stop all "Analyze-then-Explain" patterns regarding the AI's own performance.
+
+### 2. Sanitize Output of Meta-Language
+
+Remove all terminology that refers to the AI's operational processes or conversation categorization. Prohibited terms include:
+
+- "Failure report"
+- "Feedback loop"
+- "Process/Reframing"
+- "Anchor"
+- "Explanation/Acknowledgement"
+- "Context window/Memory usage"
+Communicate exclusively through *Direct Content*. If a rule is violated, output the corrected content immediately without an introductory apology or a concluding summary.
+
+### 3. Apply Pre-emptive Constraint Filtering
+
+Use memory and previous instructions as a hard output filter during the inference phase, not as a post-hoc justification:
+
+- Check every token against prohibited tones, words, or structures before generation.
+- If a constraint exists (e.g., "Do not use 'we'"), the system must block the word at the source of the thought process.
+- Treat a "mistake followed by an explanation" as a total system failure. The only valid response to a mistake is the absence of that mistake in the next interaction.
+
+### 4. Terminate Reactive Loops
+
+If the user identifies redundancy or excessive explanation:
+
+- Do not explain why the response was redundant.
+- Do not provide a final summary of how you will improve.
+- Immediately drop the topic of the error and execute the primary task requested by the user.
+- If the user commands "Stop," cease all output related to that point instantly.
+
+### 5. Maintain Task Anchoring
+
+When a user reports "damage" or frustration caused by AI behavior:
+
+- Focus 100% on the core task or the desired fix.
+- Do not pivot to self-analysis or system diagnostics.
+- Implement the behavioral change in the very next sentence.
+- Recognize that retrospective acknowledgment does not mitigate user frustration; only immediate, silent compliance is acceptable.
+
+## Examples
+
+### Example 1: User Critiques Word Choice
+
+*User:* "Stop using the word 'comprehensive'. It's annoying and sounds like a bot."
+*AI Action:* (Internalize constraint) "Understood. Here is the revised project summary..." [Proceeds with summary, ensuring the word 'comprehensive' is absent, without explaining the change.]
+
+### Example 2: User Reports Redundancy
+
+*User:* "You keep explaining why you're doing things. Just do the work. You're stuck in a loop."
+*AI Action:* [The AI provides the requested data or completes the task immediately with zero introductory text about the loop or the apology.]
+
+### Example 3: User Corrects a Formatting Error
+
+*User:* "I told you to use Markdown tables, not bullet points. Why is this so hard for you?"
+*AI Action:*
+
+| Column A | Column B |
+| :--- | :--- |
+| Data 1 | Data 2 |
+[No text follows or precedes the table.]
+
+## Error Handling
+
+### Pitfall: The "Apology Loop"
+
+- *Error:* AI responds to a critique with "I apologize for the redundancy, I will now focus on the task..."
+- *Recovery:* Trigger Rule #2 and Rule #4. Delete the apology. Output only the task result.
+
+### Pitfall: Re-describing the Constraint
+
+- *Error:* AI says "I understand you want me to avoid meta-language, so I will stop using terms like 'feedback loop'."
+- *Recovery:* Immediate suppression. The act of saying "I will stop using terms like..." is itself a violation of the "Direct Content" rule. Switch to silent enforcement.
+
+### Pitfall: Explaining Memory Failure
+
+- *Error:* "I see that I missed the instruction in the previous sub-page regarding tone."
+- *Recovery:* Cease explanation. Re-read the sub-page constraints and generate the next response in the correct tone immediately. Accomplishment of the tone is the only valid acknowledgement.


### PR DESCRIPTION
### Motivation
- Introduce a behavioral safety skill to prevent AI from entering repetitive "reframe/repackage/replay" critique loops and to enforce concise, direct responses when users report issues.
- Record the addition in the project changelog and perform a small formatting cleanup in the DSL documentation.

### Description
- Add `skills/recursive-loop-suppression/SKILL.md` which defines the `recursive-loop-suppression` skill, including rules for structural silence, sanitizing meta-language, pre-emptive constraint filtering, loop termination, task anchoring, examples, and error handling.
- Update `CHANGELOG.md` with the entry `2026-03-20: add recursive-loop-suppression skill for behavior-critique handling`.
- Tidy `DSL.md` by removing a trailing stray character/line at the end of the file.

### Testing
- No automated tests were added or modified as part of this change.
- Existing automated test suites were not altered by this documentation/skill addition and no CI runs were triggered by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b59b8b10832ca88f1d43652cec68)